### PR TITLE
Add ability to get pinned ref/mut from buffer wrapper types (Limit/Take)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ allocator_api = []
 core_io_borrowed_buf = []
 
 [dependencies]
-pin-project-lite = "0.2.13"
+pin-project-lite = "0.2"
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ allocator_api = []
 core_io_borrowed_buf = []
 
 [dependencies]
+pin-project-lite = "0.2.13"
 serde = { version = "1.0.60", optional = true, default-features = false, features = ["alloc"] }
 
 [dev-dependencies]

--- a/src/buf/limit.rs
+++ b/src/buf/limit.rs
@@ -2,13 +2,18 @@ use crate::buf::UninitSlice;
 use crate::BufMut;
 
 use core::cmp;
+use core::pin::Pin;
+use pin_project_lite::pin_project;
 
-/// A `BufMut` adapter which limits the amount of bytes that can be written
-/// to an underlying buffer.
-#[derive(Debug)]
-pub struct Limit<T> {
-    inner: T,
-    limit: usize,
+pin_project! {
+    /// A `BufMut` adapter which limits the amount of bytes that can be written
+    /// to an underlying buffer.
+    #[derive(Debug)]
+    pub struct Limit<T> {
+        #[pin]
+        inner: T,
+        limit: usize,
+    }
 }
 
 pub(super) fn new<T>(inner: T, limit: usize) -> Limit<T> {
@@ -28,11 +33,25 @@ impl<T> Limit<T> {
         &self.inner
     }
 
+    /// Gets a pinned reference to the underlying `BufMut`.
+    ///
+    /// It is inadvisable to directly write to the underlying `BufMut`.
+    pub fn get_pinned_ref(self: Pin<&Self>) -> Pin<&T> {
+        self.project_ref().inner
+    }
+
     /// Gets a mutable reference to the underlying `BufMut`.
     ///
     /// It is inadvisable to directly write to the underlying `BufMut`.
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
+    }
+
+    /// Gets a pinned mutable reference to the underlying `BufMut`.
+    ///
+    /// It is inadvisable to directly write to the underlying `BufMut`.
+    pub fn get_pinned_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner
     }
 
     /// Returns the maximum number of bytes that can be written

--- a/src/buf/take.rs
+++ b/src/buf/take.rs
@@ -1,15 +1,20 @@
 use crate::{Buf, Bytes, SeekBuf};
 
 use core::cmp;
+use core::pin::Pin;
+use pin_project_lite::pin_project;
 
-/// A `Buf` adapter which limits the bytes read from an underlying buffer.
-///
-/// This struct is generally created by calling `take()` on `Buf`. See
-/// documentation of [`take()`](Buf::take) for more details.
-#[derive(Debug)]
-pub struct Take<T> {
-    inner: T,
-    limit: usize,
+pin_project! {
+    /// A `Buf` adapter which limits the bytes read from an underlying buffer.
+    ///
+    /// This struct is generally created by calling `take()` on `Buf`. See
+    /// documentation of [`take()`](Buf::take) for more details.
+    #[derive(Debug)]
+    pub struct Take<T> {
+        #[pin]
+        inner: T,
+        limit: usize,
+    }
 }
 
 pub fn new<T>(inner: T, limit: usize) -> Take<T> {
@@ -57,6 +62,13 @@ impl<T> Take<T> {
         &self.inner
     }
 
+    /// Gets a pinned reference to the underlying `Buf`.
+    ///
+    /// It is inadvisable to directly read from the underlying `Buf`.
+    pub fn get_pinned_ref(self: Pin<&Self>) -> Pin<&T> {
+        self.project_ref().inner
+    }
+
     /// Gets a mutable reference to the underlying `Buf`.
     ///
     /// It is inadvisable to directly read from the underlying `Buf`.
@@ -76,6 +88,13 @@ impl<T> Take<T> {
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
         &mut self.inner
+    }
+
+    /// Gets a pinned mutable reference to the underlying `Buf`.
+    ///
+    /// It is inadvisable to directly read from the underlying `Buf`.
+    pub fn get_pinned_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner
     }
 
     /// Returns the maximum number of bytes that can be read.


### PR DESCRIPTION
Allows any buffers that are wrapped in `Take`/`Limit` to be accessed through a pin.